### PR TITLE
update h2 to get rid of a multi-threading issue

### DIFF
--- a/sma-server/pom.xml
+++ b/sma-server/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.173</version>
+            <version>1.4.177</version>
         </dependency>
 
         <dependency>

--- a/sma-server/src/main/java/fr/insalyon/creatis/sma/server/dao/H2DAOFactory.java
+++ b/sma-server/src/main/java/fr/insalyon/creatis/sma/server/dao/H2DAOFactory.java
@@ -50,7 +50,7 @@ public class H2DAOFactory extends DAOFactory {
     private static final Logger logger = Logger.getLogger(H2DAOFactory.class);
     private static H2DAOFactory instance;
     private final String DRIVER = "org.h2.Driver";
-    private final String DBURL = "jdbc:h2:db/sma.db";
+    private final String DBURL = "jdbc:h2:./db/sma.db";
     private Connection connection;
 
     public static H2DAOFactory getInstance() {


### PR DESCRIPTION
h2 version 1.3.173 caused a deadlock when multiple messages were send at the same time.
It worked in 1.3.170, but I updated it to the last 1.x available version, as 2.x is not retrocompatible.